### PR TITLE
Fix encoding for Py3.4-3.7

### DIFF
--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1316,14 +1316,13 @@ orig_argv = argv;
 
         if (SYSFLAG_UTF8) {
             encoding = "utf-8";
+            Py_SetStandardStreamEncoding(encoding, NULL);
         } else {
             encoding = getenv("PYTHONIOENCODING");
-            if (encoding == NULL) {
-                encoding = "utf-8";
+            if (encoding != NULL) {
+                Py_SetStandardStreamEncoding(encoding, NULL);
             }
         }
-
-        Py_SetStandardStreamEncoding(encoding, NULL);
     }
 #endif
 

--- a/nuitka/freezer/IncludedDataFiles.py
+++ b/nuitka/freezer/IncludedDataFiles.py
@@ -199,7 +199,7 @@ default_ignored_suffixes = (
     ".so",
     ".pyd",
     ".pyx",
-    ".dll",
+    #".dll",
     ".dylib",
 )
 


### PR DESCRIPTION
IncludedDataFiles: Don't ignore dll files